### PR TITLE
検索結果の文字の省略 20230531

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@heroicons/react": "^2.0.18",
         "@tailwindcss/forms": "^0.5.3",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@types/debounce": "^1.2.1",
         "@types/node": "^20.2.5",
         "@types/react": "^18.2.7",
@@ -1364,6 +1365,15 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "dev": true,
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@heroicons/react": "^2.0.18",
     "@tailwindcss/forms": "^0.5.3",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@types/debounce": "^1.2.1",
     "@types/node": "^20.2.5",
     "@types/react": "^18.2.7",

--- a/src/pages/create-post.tsx
+++ b/src/pages/create-post.tsx
@@ -61,8 +61,8 @@ const CreatePost = () => {
             {...register("title", {
               required: "必須入力です",
               maxLength: {
-                value: 50,
-                message: "最大50文字です",
+                value: 100,
+                message: "最大100文字です",
               },
             })}
             id="title"
@@ -85,8 +85,8 @@ const CreatePost = () => {
             {...register("body", {
               required: "必須入力です",
               maxLength: {
-                value: 50,
-                message: "最大50文字です",
+                value: 400,
+                message: "最大400文字です",
               },
             })}
             id="body"

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -40,13 +40,13 @@ const Hit: HitsProps<Post>["hitComponent"] = ({ hit }) => {
 
   return (
     <div className="rounded-md shadow p-4">
-      <h2>{hit.title}</h2>
+      <h2 className="line-clamp-2">{hit.title}</h2>
       {/* firestoreから日付のデータを取得できないため、一時的に定数を入れている */}
       <p className="text-slate-500">
         {format(1685269825108, "yyyy年MM月dd日")}
       </p>
       {/* <p>{hit.createdAt}</p> */}
-      <p>{user && user.name}</p>
+      {user && <p className="truncate">{user.name}</p>}
     </div>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,5 +18,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("@tailwindcss/forms")],
+  plugins: [require("@tailwindcss/forms"), require("@tailwindcss/line-clamp")],
 };


### PR DESCRIPTION
検索結果のタイトルと内容の文字数が多い時にその文字数を省略する機能を付け加えた。
・tailwind clampを使用してタイトルを表示する行を指定した
・tailwindcssに備わっているtruncateで文章を省略した
