### PR TITLE
記事編集・削除機能の実装 20230608

### DIFF
--- a/components/post-form.tsx
+++ b/components/post-form.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { Post } from "../types/post";
 import classNames from "classnames";
 import Button from "../components/button";
-import { collection, doc, getDoc, setDoc } from "firebase/firestore";
+import { collection, deleteDoc, doc, getDoc, setDoc } from "firebase/firestore";
 import { auth, db } from "../firebase/client";
 import { useAuth } from "../context/auth";
 import { useRouter } from "next/router";
@@ -75,6 +75,14 @@ const PostForm = ({ isEditMode }: { isEditMode: boolean }) => {
     });
   };
 
+  const deletePost = () => {
+    const ref = doc(db, `posts/${editTargetId}`);
+    return deleteDoc(ref).then(() => {
+      alert("記事を削除しました");
+      router.push("/");
+    });
+  };
+
   return (
     <div>
       <h1>記事{isEditMode ? "編集" : "投稿"}</h1>
@@ -129,6 +137,9 @@ const PostForm = ({ isEditMode }: { isEditMode: boolean }) => {
         </div>
 
         <Button>{isEditMode ? "保存" : "投稿"}</Button>
+        <button type="button" onClick={deletePost}>
+          削除
+        </button>
       </form>
     </div>
   );

--- a/src/pages/posts/[id]/index.tsx
+++ b/src/pages/posts/[id]/index.tsx
@@ -4,6 +4,7 @@ import { adminDB } from "../../../../firebase/server";
 import { useUser } from "../../../../lib/user";
 import { Post } from "../../../../types/post";
 import Link from "next/link";
+import { useAuth } from "../../../../context/auth";
 
 export const getStaticProps: GetStaticProps<{ post: Post }> = async (
   context
@@ -29,6 +30,8 @@ const PostDetailPage = ({
   post,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const user = useUser(post?.authorId);
+  const { fbUser } = useAuth();
+  const isAuthoer = fbUser?.uid === post?.authorId;
 
   if (!post) {
     return <p>記事が存在しません</p>;
@@ -51,6 +54,11 @@ const PostDetailPage = ({
         </div>
       )}
       <p>{post.body}</p>
+      {isAuthoer && (
+        <Link href={`/posts/${post.id}/edit`} className="text-slate-500">
+          編集
+        </Link>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
記事の編集画面へのルート作成と削除機能を実装した。
削除機能はfirebasestoreのdbから記事のidを取得し、deleteDocメソッドを使うことで削除した。firebasestoreで削除する事で拡張機能を用いて自動的にalgoliaの記事も削除している。