### PR TITLE
画像のアップロード 20230614

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -8,7 +8,7 @@ const Button = ({
 }) => {
   return (
     <button
-      className="px-4 py-2 rounded-full bg-blue-500 text-white shadow"
+      className="px-4 py-2 rounded-full bg-blue-500 text-white shadow disabled:opacity-30"
       {...props}
     >
       {children}

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -2,6 +2,7 @@ import { Menu, Transition } from "@headlessui/react";
 import Link from "next/link";
 import { Fragment, ReactNode, forwardRef } from "react";
 import { logout } from "../lib/auth";
+import { useAuth } from "../context/auth";
 
 const items = [
   {
@@ -37,10 +38,21 @@ const MyLink = forwardRef<
 MyLink.displayName = "MyLink";
 
 const UserMenu = () => {
+  const { user } = useAuth();
+
+  if (!user) {
+    return null;
+  }
   return (
     <Menu as="div" className="relative inline-block text-left">
       <div>
-        <Menu.Button className="bg-slate-300 block rounded-full w-9 h-9"></Menu.Button>
+        <Menu.Button className="block rounded-full w-9 h-9 overflow-hidden">
+          <img
+            src={user.avatarURL}
+            className="w-full h-full object-cover block"
+            alt=""
+          />
+        </Menu.Button>
       </div>
       <Transition
         as={Fragment}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,5 +18,7 @@ module.exports = {
       },
     },
   },
-  plugins: [require("@tailwindcss/forms"), require("@tailwindcss/line-clamp")],
+  plugins: [require("@tailwindcss/forms")],
 };
+
+//  plugins: [require("@tailwindcss/line-clamp")]


### PR DESCRIPTION
画像を表示する時に、そのままの画像を表示させると容量を多く使ってしまうため、一度firebase storageに画像を保存して、そこからURLを取得して使用することで容量を軽くした。その実装を以下に示す。
・user-formのsubmitで画像データをURLに変換して指定のファイルに保存・削除機能を作った。
・firebase storageでのルールを変更してユーザーに権限を設けた。
・useEffectでユーザーが存在する場合の初期値を入れた。
・Buttonにdisabled={isSubmitting}を入れることによって一連の処理が終わらないとボタンを押せないようにする機能を実装した。
・ヘッダーの画像にも反映するように実装した。