### PR TITLE
ページ遷移時にサイドバーを閉じる 20230614

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,7 +1,8 @@
 import { Dialog, Transition } from "@headlessui/react";
 import Image from "next/image";
 import Link from "next/link";
-import { Fragment, useState } from "react";
+import { useRouter } from "next/router";
+import { Fragment, useEffect } from "react";
 
 const links = [
   {
@@ -52,6 +53,11 @@ const Sidebar = ({
   isOpen: boolean;
   closeModal: VoidFunction;
 }) => {
+  const router = useRouter();
+  useEffect(() => {
+    router.events.on("routeChangeStart", closeModal);
+    return () => router.events.off("routeChangeStart", closeModal);
+  }, []);
   return (
     <>
       <Transition appear show={isOpen} as={Fragment}>


### PR DESCRIPTION
componentsのsidebarにuseEffectを使い、router.eventを用いることでルート時にサイドバーを閉じる機能を付け加えた。