### PR TITLE
トップ画面の実装 20230614

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -41,7 +41,12 @@ const Header = () => {
               />
             </a>
           </Link>
-          <span className="flex-1"></span>
+          <span className="flex-1" />
+          {user && (
+            <Link legacyBehavior href="create-post">
+              <a className="mr-4">投稿</a>
+            </Link>
+          )}
           {user ? (
             <UserMenu />
           ) : (

--- a/components/post-form.tsx
+++ b/components/post-form.tsx
@@ -7,6 +7,7 @@ import { collection, deleteDoc, doc, getDoc, setDoc } from "firebase/firestore";
 import { auth, db } from "../firebase/client";
 import { useAuth } from "../context/auth";
 import { useRouter } from "next/router";
+import { revalidate } from "../lib/revalidate";
 
 // 投稿をfirestoreとalgoliaに保存する機能
 const PostForm = ({ isEditMode }: { isEditMode: boolean }) => {
@@ -54,16 +55,9 @@ const PostForm = ({ isEditMode }: { isEditMode: boolean }) => {
     };
 
     setDoc(ref, post).then(async () => {
-      const path = `/posts/${post.id}`;
+      await revalidate("/");
 
-      const token = await auth.currentUser?.getIdToken(true);
-
-      fetch(`/api/revalidate?path=${path}`, {
-        method: "POST",
-        headers: {
-          Authorization: "Bearer " + token,
-        },
-      })
+      return revalidate(`/posts/${post.id}`)
         .then((res) => res.json())
         .then(() => {
           alert(`記事を${isEditMode ? "更新" : "作成"}しました`);
@@ -77,8 +71,12 @@ const PostForm = ({ isEditMode }: { isEditMode: boolean }) => {
 
   const deletePost = () => {
     const ref = doc(db, `posts/${editTargetId}`);
-    return deleteDoc(ref).then(() => {
+    return deleteDoc(ref).then(async () => {
       alert("記事を削除しました");
+
+      await revalidate("/");
+      await revalidate(`/posts/${editTargetId}`);
+
       router.push("/");
     });
   };
@@ -137,9 +135,11 @@ const PostForm = ({ isEditMode }: { isEditMode: boolean }) => {
         </div>
 
         <Button>{isEditMode ? "保存" : "投稿"}</Button>
-        <button type="button" onClick={deletePost}>
-          削除
-        </button>
+        {isEditMode && (
+          <button type="button" onClick={deletePost}>
+            削除
+          </button>
+        )}
       </form>
     </div>
   );

--- a/components/post-item-card.tsx
+++ b/components/post-item-card.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { useUser } from "../lib/user";
+import { Post } from "../types/post";
+import { format } from "date-fns";
+
+// 検索ワードに対して記事のタイトル・日付・著者が返される機能
+const PostItemCard = ({ post }: { post: Post }) => {
+  const user = useUser(post.authorId);
+
+  return (
+    <div className="rounded-md shadow p-4">
+      <h2 className="line-clamp-2">
+        <Link legacyBehavior href={`posts/${post.id}`}>
+          <a>{post.title}</a>
+        </Link>
+      </h2>
+      {user && (
+        <div className="flex items-center">
+          <img
+            src={user?.avatarURL}
+            className="w-8 h-8 block rounded-full mr-2"
+            alt=""
+          />
+          <div>
+            <p className="truncate">{user.name}</p>
+            <p className="text-slate-500 text-sm">
+              {format(post.createdAt, "yyyy年MM月dd日")}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PostItemCard;

--- a/lib/revalidate.ts
+++ b/lib/revalidate.ts
@@ -1,0 +1,12 @@
+import { auth } from "../firebase/client";
+
+export const revalidate = async (path: string) => {
+  const token = await auth.currentUser?.getIdToken(true);
+
+  return fetch(`/api/revalidate?path=${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer " + token,
+    },
+  });
+};

--- a/src/pages/create-post.tsx
+++ b/src/pages/create-post.tsx
@@ -1,12 +1,19 @@
-import React from "react";
+import React, { ReactElement } from "react";
 import PostForm from "../../components/post-form";
+import Layout from "../../components/layout";
+import { NextPageWithLayout } from "./_app";
 
-const CreatePost = () => {
+const CreatePost: NextPageWithLayout = () => {
   return (
-    <div className="container">
+    <div className="container mt-6">
       <PostForm isEditMode={false} />
     </div>
   );
+};
+
+// componentsのlayoutを各ページで使用する機能
+CreatePost.getLayout = function getLayout(page: ReactElement) {
+  return <Layout>{page}</Layout>;
 };
 
 export default CreatePost;

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,58 +1,25 @@
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import algoliasearch from "algoliasearch/lite";
-import { format } from "date-fns";
 import { debounce } from "debounce";
-import Link from "next/link";
 import { ReactElement, ReactNode } from "react";
 import {
   Hits,
-  HitsProps,
   InstantSearch,
   Pagination,
   SearchBox,
   SearchBoxProps,
   useInstantSearch,
 } from "react-instantsearch-hooks-web";
-import { useUser } from "../../lib/user";
+import Layout from "../../components/layout";
 import { Post } from "../../types/post";
 import { NextPageWithLayout } from "./_app";
-import Layout from "../../components/layout";
+import PostItemCard from "../../components/post-item-card";
 
 // algoliaの検索クエリ機能を結びつける
 const searchClient = algoliasearch(
   "XFS9BODPDH",
   "e068a01b53824eb9301335e26b78da1d"
 );
-
-// 検索ワードに対して記事のタイトル・日付・著者が返される機能
-const Hit: HitsProps<Post>["hitComponent"] = ({ hit }) => {
-  const user = useUser(hit.authorId);
-
-  return (
-    <div className="rounded-md shadow p-4">
-      <h2 className="line-clamp-2">
-        <Link legacyBehavior href={`posts/${hit.id}`}>
-          <a>{hit.title}</a>
-        </Link>
-      </h2>
-      {user && (
-        <div className="flex items-center">
-          <img
-            src={user?.avatarURL}
-            className="w-8 h-8 block rounded-full mr-2"
-            alt=""
-          />
-          <div>
-            <p className="truncate">{user.name}</p>
-            <p className="text-slate-500 text-sm">
-              {format(hit.createdAt, "yyyy年MM月dd日")}
-            </p>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
 
 // 検索結果の表示を編集する処理
 const NoResultsBoundary = ({ children }: { children: ReactNode }) => {
@@ -106,13 +73,13 @@ const Search: NextPageWithLayout = () => {
           queryHook={debounce(search, 500)}
         />
         {/* １ページに入る検索結果を編集する処理 */}
-        {/* <Configure hitsPerPage={2} /> */}
+        {/* <Configure postsPerPage={2} /> */}
         <NoResultsBoundary>
           <Hits<Post>
             classNames={{
               list: "space-y-4 my-6",
             }}
-            hitComponent={Hit}
+            hitComponent={({ hit }) => <PostItemCard post={hit} />}
           />
           {/* 検索結果のページを表示・移動する処理 */}
           <Pagination


### PR DESCRIPTION
indexページに最新の投稿を表示するように実装した。
・記事のデータをalgoliaから持ってくるよりもfirebase storeから持ってきた方が圧倒的にコストが低いため、firebase storeから引っ張ってくるように実装した。
・記事を表示する機能をcomponentsにまとめてindexとsearchページで使えるようにした。
・on-demand ISRの処理(再読み込み)をlibの中のrevalidateでまとめて、複数のページで使えるようにした。
・userがいれば記事投稿ページへのリンクが表示されるようにした。
・indexをlayoutで囲んだ。
・記事編集画面であれば削除ボタンを表示させるようにした。